### PR TITLE
Fix to ::Sequel::Dataset.class_eval when doing raw query

### DIFF
--- a/lib/new_relic/agent/instrumentation/sequel.rb
+++ b/lib/new_relic/agent/instrumentation/sequel.rb
@@ -34,10 +34,10 @@ if defined? ::Sequel
   # Sequel's Dataset instance methods
   ::Sequel::Dataset.class_eval do
 
-    add_method_tracer :execute,        'ActiveRecord/#{model ? model.name : "Dataset#{first_source}"}/find'
-    add_method_tracer :execute_insert, 'ActiveRecord/#{model ? model.name : "Dataset#{first_source}"}/create'
-    add_method_tracer :execute_dui,    'ActiveRecord/#{model ? model.name : "Dataset#{first_source}"}/update'
-    add_method_tracer :execute_ddl,    'ActiveRecord/#{model ? model.name : "Dataset#{first_source}"}/all'
+    add_method_tracer :execute,        'ActiveRecord/#{defined?(model) ? model.name : sql}/find'
+    add_method_tracer :execute_insert, 'ActiveRecord/#{defined?(model) ? model.name : sql}/create'
+    add_method_tracer :execute_dui,    'ActiveRecord/#{defined?(model) ? model.name : sql}/update'
+    add_method_tracer :execute_ddl,    'ActiveRecord/#{defined?(model) ? model.name : sql}/all'
 
   end
 


### PR DESCRIPTION
I'm using Sequel in my rails project indirectly and not inheriting from Sequel::Model. Thus I was crashing since I didn't have model defined. I changed the code to add defined?(model) but then I didn't have first_source defined (because again I'm doing raw queries). So I changed it to return the raw SQL query by calling the sql method. This might not be desirable in the default case but since my SQL queries weren't getting connected to the results page, it was the only way to know what was going on.

If you want to test my use case simply define a model like this:

```
require 'sequel'
class Packet
  @@db = Sequel.oracle(<connection params>)
  def self.all(table)
    @@db["select * from #{table}"]
  end
end
```
